### PR TITLE
Add password generator web tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# Password-Generator-Tool
+# Password Generator Tool
+
+This project provides a simple web based password generator. It allows you to choose the length of the password (8–32 characters) and toggle which character sets to include. The generated password strength is estimated and you can copy it to the clipboard with a single click.
+
+## Usage
+
+Open `index.html` in any modern web browser. Adjust the length slider and select the desired character types. Press **Generate** to create a password. Use the **Copy** button to copy the password to your clipboard.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Password Generator</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Password Generator</h1>
+        <div class="controls">
+            <label for="length">Length: <span id="lengthValue">12</span></label>
+            <input type="range" id="length" min="8" max="32" value="12"/>
+            <div class="checkboxes">
+                <label><input type="checkbox" id="uppercase" checked> Uppercase</label>
+                <label><input type="checkbox" id="lowercase" checked> Lowercase</label>
+                <label><input type="checkbox" id="numbers" checked> Numbers</label>
+                <label><input type="checkbox" id="symbols" checked> Special</label>
+            </div>
+            <button id="generate">Generate</button>
+        </div>
+        <div class="output">
+            <input type="text" id="password" readonly>
+            <button id="copy">Copy</button>
+        </div>
+        <div id="strength" class="strength">Strength: <span id="strengthValue">-</span></div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,59 @@
+function updateLengthLabel(value) {
+    document.getElementById('lengthValue').textContent = value;
+}
+
+document.getElementById('length').addEventListener('input', function() {
+    updateLengthLabel(this.value);
+});
+
+document.getElementById('generate').addEventListener('click', function() {
+    const length = parseInt(document.getElementById('length').value, 10);
+    const useUpper = document.getElementById('uppercase').checked;
+    const useLower = document.getElementById('lowercase').checked;
+    const useNumbers = document.getElementById('numbers').checked;
+    const useSymbols = document.getElementById('symbols').checked;
+
+    const password = generatePassword(length, useUpper, useLower, useNumbers, useSymbols);
+    document.getElementById('password').value = password;
+    document.getElementById('strengthValue').textContent = passwordStrength(password);
+});
+
+document.getElementById('copy').addEventListener('click', function() {
+    const passField = document.getElementById('password');
+    if (passField.value) {
+        navigator.clipboard.writeText(passField.value);
+    }
+});
+
+function generatePassword(length, upper, lower, numbers, symbols) {
+    let chars = '';
+    if (upper) chars += 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+    if (lower) chars += 'abcdefghijklmnopqrstuvwxyz';
+    if (numbers) chars += '0123456789';
+    if (symbols) chars += '!@#$%^&*()_+~`|}{[]:;?><,./-=';
+
+    if (!chars) return '';
+
+    let password = '';
+    const array = new Uint32Array(length);
+    window.crypto.getRandomValues(array);
+    for (let i = 0; i < length; i++) {
+        password += chars[array[i] % chars.length];
+    }
+    return password;
+}
+
+function passwordStrength(pass) {
+    let score = 0;
+    if (pass.length >= 12) score += 1;
+    if (/[A-Z]/.test(pass) && /[a-z]/.test(pass)) score += 1;
+    if (/[0-9]/.test(pass)) score += 1;
+    if (/[^A-Za-z0-9]/.test(pass)) score += 1;
+
+    switch (score) {
+        case 4: return 'Strong';
+        case 3: return 'Good';
+        case 2: return 'Medium';
+        default: return 'Weak';
+    }
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,44 @@
+body {
+    font-family: Arial, sans-serif;
+    background: #f0f0f0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100vh;
+}
+
+.container {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0,0,0,0.1);
+    width: 320px;
+}
+
+.controls label {
+    display: block;
+    margin-bottom: 10px;
+}
+
+.checkboxes label {
+    display: block;
+}
+
+.output {
+    margin-top: 15px;
+    display: flex;
+}
+
+.output input {
+    flex: 1;
+    padding: 5px;
+    font-size: 1em;
+}
+
+.output button {
+    margin-left: 5px;
+}
+
+.strength {
+    margin-top: 10px;
+}


### PR DESCRIPTION
## Summary
- create simple HTML/CSS/JS password generator
- allow length selection, character type toggles
- display strength label and copy to clipboard
- update README with usage instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e3bd7a53c8332aca15100502df10f